### PR TITLE
Bump pywin32 to version 301 in setup requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ requirements = [
 
 extras_require = {
     # win32 APIs if on Windows (required for npipe support)
-    ':sys_platform == "win32"': 'pywin32==227',
+    ':sys_platform == "win32"': 'pywin32==301',
 
     # If using docker-py over TLS, highly recommend this option is
     # pip-installed or pinned.


### PR DESCRIPTION
CVE-2021-32559
moderate severity
Vulnerable versions: < 301
Patched version: 301
An integer overflow exists in pywin32 prior to version b301 when adding an access control entry (ACE) to an access control list (ACL) that would cause the size to be greater than 65535 bytes. An attacker who successfully exploited this vulnerability could crash the vulnerable process.